### PR TITLE
Some refactoring and the introduction of a Go routine for periodic interface rate stats collection.

### DIFF
--- a/httpserver.go
+++ b/httpserver.go
@@ -6,7 +6,6 @@ import (
 	"html/template"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -50,27 +49,13 @@ type TemplateHandler struct {
 	baseTemplate *template.Template
 }
 
-func getInterfaceIPAddressesString(iface net.Interface) string {
-	addrs, err := iface.Addrs()
-	if err != nil {
-		return err.Error()
-	}
-
-	var addrStrings = make([]string, 0, len(addrs))
-	for _, addr := range addrs {
-		addrStrings = append(addrStrings, addr.String())
-	}
-
-	return strings.Join(addrStrings, ", ")
-}
-
 func newTemplateFuncMap() template.FuncMap {
 	return template.FuncMap{
 		"timeNow":                       time.Now,
 		"localHostname":                 GetLocalHostname,
 		"getInterfaceIPAddressesString": getInterfaceIPAddressesString,
-		"readCPUInfo":                   readCPUInfo,
-		"readNetworkDeviceStats":        readNetworkDeviceStats,
+		"getCPUInfo":                    getCPUInfo,
+		"getNetworkDeviceStats":         getNetworkDeviceStats,
 		"getNetworkInterfaceRates":      getNetworkInterfaceRates,
 	}
 }

--- a/linuxproc.go
+++ b/linuxproc.go
@@ -1,107 +1,13 @@
 package main
 
 import (
-	"sort"
-	"sync"
-	"time"
-
 	linuxproc "github.com/c9s/goprocinfo/linux"
 )
 
-var (
-	interfaceRatesMu = sync.RWMutex{}
-	interfaceRates   = make(map[string]InterfaceRateStat)
-)
-
-type InterfaceRateStat struct {
-	Iface        string
-	oldRxBytes   uint64
-	oldRxPackets uint64
-	oldTxBytes   uint64
-	oldTxPackets uint64
-
-	RxBytesRate   string // bps with SI prefix
-	RxPacketsRate string // pps with SI prefix
-	TxBytesRate   string // bps with SI prefix
-	TxPacketsRate string // pps with SI prefix
-
-	lastCheckTime time.Time
+func readCPUInfo() (*linuxproc.CPUInfo, error) {
+	return linuxproc.ReadCPUInfo("/proc/cpuinfo")
 }
 
-type InterfaceRateStats []InterfaceRateStat
-
-func (l InterfaceRateStats) Len() int           { return len(l) }
-func (l InterfaceRateStats) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
-func (l InterfaceRateStats) Less(i, j int) bool { return l[i].Iface < l[j].Iface }
-
-func readCPUInfo() *linuxproc.CPUInfo {
-	cpuInfo, err := linuxproc.ReadCPUInfo("/proc/cpuinfo")
-	if err != nil {
-		Log.WithField("error", err).Error("Error reading cpuinfo.")
-		return nil
-	}
-
-	return cpuInfo
-}
-
-func readNetworkDeviceStats() []linuxproc.NetworkStat {
-	stats, err := linuxproc.ReadNetworkStat("/proc/net/dev")
-	if err != nil {
-		Log.WithField("error", err).Error("Error reading network device stats.")
-		return nil
-	}
-
-	interfaceRatesMu.Lock()
-	defer interfaceRatesMu.Unlock()
-
-	for _, stat := range stats {
-		nowTime := time.Now()
-
-		if ifaceRateStats, exists := interfaceRates[stat.Iface]; exists {
-			durationInSeconds := nowTime.Sub(ifaceRateStats.lastCheckTime).Seconds()
-
-			ifaceRateStats.RxBytesRate = SI(float64((stat.RxBytes-ifaceRateStats.oldRxBytes)*8)/durationInSeconds, 2, " ", "bit/s")
-			ifaceRateStats.RxPacketsRate = SI(float64(stat.RxPackets-ifaceRateStats.oldRxPackets)/durationInSeconds, 2, " ", "packet/s")
-			ifaceRateStats.TxBytesRate = SI(float64((stat.TxBytes-ifaceRateStats.oldTxBytes)*8)/durationInSeconds, 2, " ", "bit/s")
-			ifaceRateStats.TxPacketsRate = SI(float64(stat.TxPackets-ifaceRateStats.oldTxPackets)/durationInSeconds, 2, " ", "packet/s")
-
-			ifaceRateStats.oldRxBytes = stat.RxBytes
-			ifaceRateStats.oldRxPackets = stat.RxPackets
-			ifaceRateStats.oldTxBytes = stat.TxBytes
-			ifaceRateStats.oldTxPackets = stat.TxPackets
-
-			ifaceRateStats.lastCheckTime = nowTime
-
-			interfaceRates[stat.Iface] = ifaceRateStats
-		} else {
-			interfaceRates[stat.Iface] = InterfaceRateStat{
-				Iface:         stat.Iface,
-				oldRxBytes:    stat.RxBytes,
-				oldRxPackets:  stat.RxPackets,
-				oldTxBytes:    stat.TxBytes,
-				oldTxPackets:  stat.TxPackets,
-				RxBytesRate:   "",
-				RxPacketsRate: "",
-				TxBytesRate:   "",
-				TxPacketsRate: "",
-				lastCheckTime: nowTime}
-		}
-	}
-
-	return stats
-}
-
-func getNetworkInterfaceRates() []InterfaceRateStat {
-	interfaceRatesMu.RLock()
-	defer interfaceRatesMu.RUnlock()
-
-	rates := make(InterfaceRateStats, 0)
-
-	for _, stat := range interfaceRates {
-		rates = append(rates, stat)
-	}
-
-	sort.Sort(rates)
-
-	return rates
+func readNetworkDeviceStats() ([]linuxproc.NetworkStat, error) {
+	return linuxproc.ReadNetworkStat("/proc/net/dev")
 }

--- a/network_device.go
+++ b/network_device.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+var (
+	interfaceRatesMu = sync.RWMutex{}
+	interfaceRates   = make(map[string]InterfaceRateStat)
+)
+
+type InterfaceRateStat struct {
+	Iface        string
+	oldRxBytes   uint64
+	oldRxPackets uint64
+	oldTxBytes   uint64
+	oldTxPackets uint64
+
+	RxBytesRate   string // bps with SI prefix
+	RxPacketsRate string // pps with SI prefix
+	TxBytesRate   string // bps with SI prefix
+	TxPacketsRate string // pps with SI prefix
+
+	lastCheckTime time.Time
+}
+
+type InterfaceRateStats []InterfaceRateStat
+
+func (l InterfaceRateStats) Len() int           { return len(l) }
+func (l InterfaceRateStats) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l InterfaceRateStats) Less(i, j int) bool { return l[i].Iface < l[j].Iface }
+
+func calculateInterfaceRateStats() error {
+	interfaceRatesMu.Lock()
+	defer interfaceRatesMu.Unlock()
+
+	stats, err := readNetworkDeviceStats()
+
+	if err != nil {
+		return err
+	}
+
+	for _, stat := range stats {
+		nowTime := time.Now()
+
+		if ifaceRateStats, exists := interfaceRates[stat.Iface]; exists {
+			durationInSeconds := nowTime.Sub(ifaceRateStats.lastCheckTime).Seconds()
+
+			ifaceRateStats.RxBytesRate = SI(float64((stat.RxBytes-ifaceRateStats.oldRxBytes)*8)/durationInSeconds, 2, " ", "bit/s")
+			ifaceRateStats.RxPacketsRate = SI(float64(stat.RxPackets-ifaceRateStats.oldRxPackets)/durationInSeconds, 2, " ", "packet/s")
+			ifaceRateStats.TxBytesRate = SI(float64((stat.TxBytes-ifaceRateStats.oldTxBytes)*8)/durationInSeconds, 2, " ", "bit/s")
+			ifaceRateStats.TxPacketsRate = SI(float64(stat.TxPackets-ifaceRateStats.oldTxPackets)/durationInSeconds, 2, " ", "packet/s")
+
+			ifaceRateStats.oldRxBytes = stat.RxBytes
+			ifaceRateStats.oldRxPackets = stat.RxPackets
+			ifaceRateStats.oldTxBytes = stat.TxBytes
+			ifaceRateStats.oldTxPackets = stat.TxPackets
+
+			ifaceRateStats.lastCheckTime = nowTime
+
+			interfaceRates[stat.Iface] = ifaceRateStats
+		} else {
+			interfaceRates[stat.Iface] = InterfaceRateStat{
+				Iface:         stat.Iface,
+				oldRxBytes:    stat.RxBytes,
+				oldRxPackets:  stat.RxPackets,
+				oldTxBytes:    stat.TxBytes,
+				oldTxPackets:  stat.TxPackets,
+				RxBytesRate:   "",
+				RxPacketsRate: "",
+				TxBytesRate:   "",
+				TxPacketsRate: "",
+				lastCheckTime: nowTime}
+		}
+	}
+
+	return nil
+}
+
+func getNetworkInterfaceRates() []InterfaceRateStat {
+	interfaceRatesMu.RLock()
+	defer interfaceRatesMu.RUnlock()
+
+	rates := make(InterfaceRateStats, 0)
+
+	for _, stat := range interfaceRates {
+		rates = append(rates, stat)
+	}
+
+	sort.Sort(rates)
+
+	return rates
+}

--- a/template_helpers.go
+++ b/template_helpers.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"net"
+	"strings"
+
+	linuxproc "github.com/c9s/goprocinfo/linux"
+)
+
+func getInterfaceIPAddressesString(iface net.Interface) string {
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return err.Error()
+	}
+
+	var addrStrings = make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		addrStrings = append(addrStrings, addr.String())
+	}
+
+	return strings.Join(addrStrings, ", ")
+}
+
+func getCPUInfo() *linuxproc.CPUInfo {
+	info, err := readCPUInfo()
+	if err != nil {
+		Log.WithField("error", err).Error("Error reading cpuinfo.")
+	}
+	return info
+}
+
+func getNetworkDeviceStats() []linuxproc.NetworkStat {
+	stats, err := readNetworkDeviceStats()
+	if err != nil {
+		Log.WithField("error", err).Error("Error reading network device stats.")
+	}
+	return stats
+}

--- a/templates/cpus.html
+++ b/templates/cpus.html
@@ -1,6 +1,6 @@
 {{ template "header" }}
 
-{{ $cpuInfo:= readCPUInfo }}
+{{ $cpuInfo:= getCPUInfo }}
 
 {{ if $cpuInfo }}
   <div class="container">

--- a/templates/network.html
+++ b/templates/network.html
@@ -1,6 +1,6 @@
 {{ template "header" }}
 
-{{ $netDevStats := readNetworkDeviceStats }}
+{{ $netDevStats := getNetworkDeviceStats }}
 {{ $interfaceRateStats := getNetworkInterfaceRates }}
 
 <div class="container">


### PR DESCRIPTION
Moved all the template helpers to `template_helpers.go`. Added a `collect-iface-rate-stat-rate` command line argument to control the rate (in seconds) at which the interface rate stats are collected.