### PR TITLE
Statsd collection of /proc/net/dev

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -18,6 +18,10 @@
 		{
 			"ImportPath": "github.com/gorilla/mux",
 			"Rev": "8a875a034c69b940914d83ea03d3f1299b4d094b"
+		},
+		{
+			"ImportPath": "github.com/ooyala/go-dogstatsd",
+			"Rev": "23f2a1659b0203cd76910e56cd4e6394f14a5cbb"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/ooyala/go-dogstatsd/README.md
+++ b/Godeps/_workspace/src/github.com/ooyala/go-dogstatsd/README.md
@@ -1,0 +1,38 @@
+## Overview
+
+Package dogstatsd provides a Go DogStatsD client. DogStatsD extends StatsD - adding tags and histograms. The documentation for DogStatsD is here: http://docs.datadoghq.com/guides/dogstatsd/
+
+## Get the code
+
+    $ go get github.com/ooyala/go-dogstatsd
+
+## Usage
+
+    // Create the client
+    c, err := dogstatsd.New("127.0.0.1:8125")
+    defer c.Close()
+    if err != nil {
+      log.Fatal(err)
+    }
+    // Prefix every metric with the app name
+    c.Namespace = "flubber."
+    // Send the EC2 availability zone as a tag with every metric
+    c.Tags = append(c.Tags, "us-east-1a")
+    err = c.Gauge("request.duration", 1.2, nil, 1)
+
+	// Post info to datadog event stream
+	err = c.Info("cookie alert", "Cookies up for grabs in the kitchen!", nil)
+
+## Development
+
+Run the tests with:
+
+    $ go test
+
+## Documentation
+
+Please see: http://godoc.org/github.com/ooyala/go-dogstatsd
+
+## License
+
+go-dogstatsd is released under the [MIT license](http://www.opensource.org/licenses/mit-license.php).

--- a/Godeps/_workspace/src/github.com/ooyala/go-dogstatsd/dogstatsd.go
+++ b/Godeps/_workspace/src/github.com/ooyala/go-dogstatsd/dogstatsd.go
@@ -1,0 +1,198 @@
+// Copyright 2013 Ooyala, Inc.
+
+/*
+Package dogstatsd provides a Go DogStatsD client. DogStatsD extends StatsD - adding tags and
+histograms. Refer to http://docs.datadoghq.com/guides/dogstatsd/ for information about DogStatsD.
+
+Example Usage:
+		// Create the client
+		c, err := dogstatsd.New("127.0.0.1:8125")
+		defer c.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
+		// Prefix every metric with the app name
+		c.Namespace = "flubber."
+		// Send the EC2 availability zone as a tag with every metric
+		append(c.Tags, "us-east-1a")
+		err = c.Gauge("request.duration", 1.2, nil, 1)
+
+		// Post info to datadog event stream
+		err = c.Info("cookie alert", "Cookies up for grabs in the kitchen!", nil)
+
+dogstatsd is based on go-statsd-client.
+*/
+package dogstatsd
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"net"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+type Client struct {
+	conn net.Conn
+	// Namespace to prepend to all statsd calls
+	Namespace string
+	// Global tags to be added to every statsd call
+	Tags []string
+}
+
+// New returns a pointer to a new Client and an error.
+// addr must have the format "hostname:port"
+func New(addr string) (*Client, error) {
+	conn, err := net.Dial("udp", addr)
+	if err != nil {
+		return nil, err
+	}
+	client := &Client{conn: conn}
+	return client, nil
+}
+
+// Close closes the connection to the DogStatsD agent
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+// send handles sampling and sends the message over UDP. It also adds global namespace prefixes and tags.
+func (c *Client) send(name string, value string, tags []string, rate float64) error {
+	if rate < 1 {
+		if rand.Float64() < rate {
+			value = fmt.Sprintf("%s|@%f", value, rate)
+		} else {
+			return nil
+		}
+	}
+
+	if c.Namespace != "" {
+		name = fmt.Sprintf("%s%s", c.Namespace, name)
+	}
+
+	tags = append(c.Tags, tags...)
+	if len(tags) > 0 {
+		value = fmt.Sprintf("%s|#%s", value, strings.Join(tags, ","))
+	}
+
+	data := fmt.Sprintf("%s:%s", name, value)
+	_, err := c.conn.Write([]byte(data))
+	return err
+}
+
+// AlertType represents the supported alert_types of Datadog events.
+type AlertType string
+
+// A Datadog event priority (e.g. 'normal' or 'low')
+type PriorityType string
+
+const (
+	Info          AlertType    = "info"
+	Success       AlertType    = "success"
+	Warning       AlertType    = "warning"
+	Error         AlertType    = "error"
+	Normal        PriorityType = "normal"
+	Low           PriorityType = "low"
+	maxEventBytes              = 8192
+)
+
+// Detailed options for Event generation
+type EventOpts struct {
+	DateHappened                         time.Time
+	Priority                             PriorityType
+	Host, AggregationKey, SourceTypeName string
+	Tags                                 []string
+	AlertType                            AlertType
+}
+
+func newDefaultEventOpts(alertType AlertType, tags []string, namespace string) *EventOpts {
+	eo := EventOpts{
+		AlertType: alertType,
+		Tags:      tags,
+	}
+	// Use the given client namespace as the source type name, if given
+	if namespace != "" {
+		source := namespace
+		if period := strings.IndexByte(source, '.'); period > -1 {
+			source = source[:period]
+		}
+		eo.SourceTypeName = source
+	}
+	return &eo
+}
+
+// Event posts to the Datadog event stream.
+// Four event types are supported: info, success, warning, error.
+// If client Namespace is set it is used as the Event source.
+func (c *Client) Info(title string, text string, tags []string) error {
+	return c.Event(title, text, newDefaultEventOpts(Info, tags, c.Namespace))
+}
+func (c *Client) Success(title string, text string, tags []string) error {
+	return c.Event(title, text, newDefaultEventOpts(Success, tags, c.Namespace))
+}
+func (c *Client) Warning(title string, text string, tags []string) error {
+	return c.Event(title, text, newDefaultEventOpts(Warning, tags, c.Namespace))
+}
+func (c *Client) Error(title string, text string, tags []string) error {
+	return c.Event(title, text, newDefaultEventOpts(Error, tags, c.Namespace))
+}
+func (c *Client) Event(title string, text string, eo *EventOpts) error {
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "_e{%d,%d}:%s|%s|t:%s", utf8.RuneCountInString(title),
+		utf8.RuneCountInString(text), title, text, eo.AlertType)
+
+	if eo.SourceTypeName != "" {
+		fmt.Fprintf(&b, "|s:%s", eo.SourceTypeName)
+	}
+	if !eo.DateHappened.IsZero() {
+		fmt.Fprintf(&b, "|d:%d", eo.DateHappened.Unix())
+	}
+	if eo.Priority != "" {
+		fmt.Fprintf(&b, "|p:%s", eo.Priority)
+	}
+	if eo.Host != "" {
+		fmt.Fprintf(&b, "|h:%s", eo.Host)
+	}
+	if eo.AggregationKey != "" {
+		fmt.Fprintf(&b, "|k:%s", eo.AggregationKey)
+	}
+	tags := append(c.Tags, eo.Tags...)
+	format := "|#%s"
+	for _, t := range tags {
+		fmt.Fprintf(&b, format, t)
+		format = ",%s"
+	}
+
+	bytes := b.Bytes()
+	if len(bytes) > maxEventBytes {
+		return fmt.Errorf("Event '%s' payload is too big (more that 8KB), event discarded", title)
+	}
+	_, err := c.conn.Write(bytes)
+	return err
+}
+
+// Gauges measure the value of a metric at a particular time
+func (c *Client) Gauge(name string, value float64, tags []string, rate float64) error {
+	stat := fmt.Sprintf("%f|g", value)
+	return c.send(name, stat, tags, rate)
+}
+
+// Counters track how many times something happened per second
+func (c *Client) Count(name string, value int64, tags []string, rate float64) error {
+	stat := fmt.Sprintf("%d|c", value)
+	return c.send(name, stat, tags, rate)
+}
+
+// Histograms track the statistical distribution of a set of values
+func (c *Client) Histogram(name string, value float64, tags []string, rate float64) error {
+	stat := fmt.Sprintf("%f|h", value)
+	return c.send(name, stat, tags, rate)
+}
+
+// Sets count the number of unique elements in a group
+func (c *Client) Set(name string, value string, tags []string, rate float64) error {
+	stat := fmt.Sprintf("%s|s", value)
+	return c.send(name, stat, tags, rate)
+}

--- a/Godeps/_workspace/src/github.com/ooyala/go-dogstatsd/dogstatsd_test.go
+++ b/Godeps/_workspace/src/github.com/ooyala/go-dogstatsd/dogstatsd_test.go
@@ -1,0 +1,164 @@
+// Copyright 2013 Ooyala, Inc.
+
+package dogstatsd
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+)
+
+var dogstatsdTests = []struct {
+	GlobalNamespace string
+	GlobalTags      []string
+	Method          string
+	Metric          string
+	Value           interface{}
+	Tags            []string
+	Rate            float64
+	Expected        string
+}{
+	{"", nil, "Gauge", "test.gauge", 1.0, nil, 1.0, "test.gauge:1.000000|g"},
+	{"", nil, "Gauge", "test.gauge", 1.0, nil, 0.999999, "test.gauge:1.000000|g|@0.999999"},
+	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 1.0, "test.gauge:1.000000|g|#tagA"},
+	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA", "tagB"}, 1.0, "test.gauge:1.000000|g|#tagA,tagB"},
+	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 0.999999, "test.gauge:1.000000|g|@0.999999|#tagA"},
+	{"", nil, "Count", "test.count", int64(1), []string{"tagA"}, 1.0, "test.count:1|c|#tagA"},
+	{"", nil, "Count", "test.count", int64(-1), []string{"tagA"}, 1.0, "test.count:-1|c|#tagA"},
+	{"", nil, "Histogram", "test.histogram", 2.3, []string{"tagA"}, 1.0, "test.histogram:2.300000|h|#tagA"},
+	{"", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagA"},
+	{"flubber.", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "flubber.test.set:uuid|s|#tagA"},
+	{"", []string{"tagC"}, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagC,tagA"},
+}
+
+func TestClient(t *testing.T) {
+	addr := "localhost:1201"
+	server := newServer(t, addr)
+	defer server.Close()
+	client := newClient(t, addr)
+	defer client.Close()
+
+	for _, tt := range dogstatsdTests {
+		client.Namespace = tt.GlobalNamespace
+		client.Tags = tt.GlobalTags
+		method := reflect.ValueOf(client).MethodByName(tt.Method)
+		e := method.Call([]reflect.Value{
+			reflect.ValueOf(tt.Metric),
+			reflect.ValueOf(tt.Value),
+			reflect.ValueOf(tt.Tags),
+			reflect.ValueOf(tt.Rate)})[0]
+		errInter := e.Interface()
+		if errInter != nil {
+			t.Fatal(errInter.(error))
+		}
+
+		message := serverRead(t, server)
+		if message != tt.Expected {
+			t.Errorf("Expected: %s. Actual: %s", tt.Expected, message)
+		}
+	}
+
+}
+
+type eventTest struct {
+	logEvent func(*Client) error
+	expected string
+}
+
+var eventTests = []eventTest{
+	eventTest{
+		logEvent: func(c *Client) error { return c.Warning("title", "text", []string{"tag1", "tag2"}) },
+		expected: "_e{5,4}:title|text|t:warning|s:flubber|#tag1,tag2",
+	},
+	eventTest{
+		logEvent: func(c *Client) error { return c.Error("Error!", "some error", []string{"tag3"}) },
+		expected: "_e{6,10}:Error!|some error|t:error|s:flubber|#tag3",
+	},
+	eventTest{
+		logEvent: func(c *Client) error { return c.Info("FYI", "note", []string{}) },
+		expected: "_e{3,4}:FYI|note|t:info|s:flubber",
+	},
+	eventTest{
+		logEvent: func(c *Client) error { return c.Success("Great News", "hurray", []string{"foo", "bar", "baz"}) },
+		expected: "_e{10,6}:Great News|hurray|t:success|s:flubber|#foo,bar,baz",
+	},
+	eventTest{
+		logEvent: func(c *Client) error { return c.Info("Unicode", "世界", []string{}) },
+		// Expect character, not byte lengths
+		expected: "_e{7,2}:Unicode|世界|t:info|s:flubber",
+	},
+	eventTest{
+		logEvent: func(c *Client) error {
+			eo := EventOpts{
+				DateHappened:   time.Date(2014, time.September, 18, 22, 56, 0, 0, time.UTC),
+				Priority:       Normal,
+				Host:           "node.example.com",
+				AggregationKey: "foo",
+				SourceTypeName: "bar",
+				AlertType:      Success,
+			}
+			return c.Event("custom title", "custom body", &eo)
+		},
+		expected: "_e{12,11}:custom title|custom body|t:success|s:bar|d:1411080960|p:normal|h:node.example.com|k:foo",
+	},
+}
+
+func TestEvent(t *testing.T) {
+	addr := "localhost:1201"
+	server := newServer(t, addr)
+	defer server.Close()
+	client := newClient(t, addr)
+	client.Namespace = "flubber."
+
+	for _, tt := range eventTests {
+		if err := tt.logEvent(client); err != nil {
+			t.Fatal(err)
+		}
+		message := serverRead(t, server)
+		if message != tt.expected {
+			t.Errorf("Expected: %s. Actual: %s", tt.expected, message)
+		}
+	}
+
+	var b bytes.Buffer
+	for i := 0; i < maxEventBytes+1; i++ {
+		fmt.Fprintf(&b, "a")
+	}
+	err := client.Error("too long", b.String(), []string{})
+	if err == nil || err.Error() != "Event 'too long' payload is too big (more that 8KB), event discarded" {
+		t.Errorf("Expected error due to exceeded event byte length")
+	}
+}
+
+func serverRead(t *testing.T, server *net.UDPConn) string {
+	bytes := make([]byte, 1024)
+	n, _, err := server.ReadFrom(bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(bytes[:n])
+}
+
+func newClient(t *testing.T, addr string) *Client {
+	client, err := New(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func newServer(t *testing.T, addr string) *net.UDPConn {
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return server
+}

--- a/linuxproc.go
+++ b/linuxproc.go
@@ -4,10 +4,15 @@ import (
 	linuxproc "github.com/c9s/goprocinfo/linux"
 )
 
+const (
+	CPUInfoPath     = "/proc/cpuinfo"
+	NetworkStatPath = "/proc/net/dev"
+)
+
 func readCPUInfo() (*linuxproc.CPUInfo, error) {
-	return linuxproc.ReadCPUInfo("/proc/cpuinfo")
+	return linuxproc.ReadCPUInfo(CPUInfoPath)
 }
 
 func readNetworkDeviceStats() ([]linuxproc.NetworkStat, error) {
-	return linuxproc.ReadNetworkStat("/proc/net/dev")
+	return linuxproc.ReadNetworkStat(NetworkStatPath)
 }

--- a/statsd.go
+++ b/statsd.go
@@ -1,7 +1,10 @@
 package main
 
-func collectNetworkDeviceStats() {
+import (
+	"encoding/json"
+)
 
+func collectNetworkDeviceStats() {
 	stats, err := readNetworkDeviceStats()
 
 	if err != nil {
@@ -9,6 +12,13 @@ func collectNetworkDeviceStats() {
 	}
 
 	for _, stat := range stats {
+		jsonBytes, err := json.Marshal(stat)
+		if err != nil {
+			Log.WithField("error", err).Errorf("Error JSON marshalling: %+v.", stat)
+		}
+
+		Log.WithField("metric", NetworkStatPath).Infof(string(jsonBytes))
+
 		// Rx stats
 		if err := StatsdClient.Count("net.dev.rxbytes", int64(stat.RxBytes), []string{"iface:" + stat.Iface}, 1); err != nil {
 			Log.WithField("error", err).Error("Couldn't submit event to statsd.")

--- a/statsd.go
+++ b/statsd.go
@@ -1,0 +1,64 @@
+package main
+
+func collectNetworkDeviceStats() {
+
+	stats, err := readNetworkDeviceStats()
+
+	if err != nil {
+		Log.WithField("error", err).Error("Error reading network device stats. Can't collect network device stats.")
+	}
+
+	for _, stat := range stats {
+		// Rx stats
+		if err := StatsdClient.Count("net.dev.rxbytes", int64(stat.RxBytes), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.rxpackets", int64(stat.RxPackets), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.rxerrs", int64(stat.RxErrs), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.rxdrop", int64(stat.RxDrop), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.rxfifo", int64(stat.RxFifo), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.rxframe", int64(stat.RxFrame), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.rxcompressed", int64(stat.RxCompressed), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.rxmulticast", int64(stat.RxMulticast), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+
+		// Tx stats
+		if err := StatsdClient.Count("net.dev.txbytes", int64(stat.TxBytes), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.txpackets", int64(stat.TxPackets), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.txerrs", int64(stat.TxErrs), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.txdrop", int64(stat.TxDrop), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.txfifo", int64(stat.TxFifo), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.txcolls", int64(stat.TxColls), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.txcarrier", int64(stat.TxCarrier), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+		if err := StatsdClient.Count("net.dev.txcompressed", int64(stat.TxCompressed), []string{"iface:" + stat.Iface}, 1); err != nil {
+			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+		}
+	}
+}


### PR DESCRIPTION
Stats from `/proc/net/dev` are now collected and sent to `StatsD`. The stats are also logged in JSON format to `stdout`.