### PR TITLE
Allows for a "stats-interface-filter" command line option.

### DIFF
--- a/statsd.go
+++ b/statsd.go
@@ -19,56 +19,60 @@ func collectNetworkDeviceStats() {
 
 		Log.WithField("metric", NetworkStatPath).Infof(string(jsonBytes))
 
-		// Rx stats
-		if err := StatsdClient.Count("net.dev.rxbytes", int64(stat.RxBytes), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.rxpackets", int64(stat.RxPackets), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.rxerrs", int64(stat.RxErrs), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.rxdrop", int64(stat.RxDrop), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.rxfifo", int64(stat.RxFifo), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.rxframe", int64(stat.RxFrame), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.rxcompressed", int64(stat.RxCompressed), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.rxmulticast", int64(stat.RxMulticast), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
+		if ifaceRegExp == nil || !ifaceRegExp.MatchString(stat.Iface) {
+			// Rx stats
+			if err := StatsdClient.Count("net.dev.rxbytes", int64(stat.RxBytes), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.rxpackets", int64(stat.RxPackets), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.rxerrs", int64(stat.RxErrs), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.rxdrop", int64(stat.RxDrop), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.rxfifo", int64(stat.RxFifo), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.rxframe", int64(stat.RxFrame), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.rxcompressed", int64(stat.RxCompressed), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.rxmulticast", int64(stat.RxMulticast), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
 
-		// Tx stats
-		if err := StatsdClient.Count("net.dev.txbytes", int64(stat.TxBytes), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.txpackets", int64(stat.TxPackets), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.txerrs", int64(stat.TxErrs), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.txdrop", int64(stat.TxDrop), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.txfifo", int64(stat.TxFifo), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.txcolls", int64(stat.TxColls), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.txcarrier", int64(stat.TxCarrier), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
-		}
-		if err := StatsdClient.Count("net.dev.txcompressed", int64(stat.TxCompressed), []string{"iface:" + stat.Iface}, 1); err != nil {
-			Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			// Tx stats
+			if err := StatsdClient.Count("net.dev.txbytes", int64(stat.TxBytes), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.txpackets", int64(stat.TxPackets), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.txerrs", int64(stat.TxErrs), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.txdrop", int64(stat.TxDrop), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.txfifo", int64(stat.TxFifo), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.txcolls", int64(stat.TxColls), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.txcarrier", int64(stat.TxCarrier), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+			if err := StatsdClient.Count("net.dev.txcompressed", int64(stat.TxCompressed), []string{"iface:" + stat.Iface}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+		} else {
+			Log.Infof("Filtered interface %s from network device stat collection.", stat.Iface)
 		}
 	}
 }


### PR DESCRIPTION
Allows for a `stats-interface-filter` command line option to be specified which contains a regular expression which filters out interfaces not reported to DogStatd.