### PR TITLE
Add support for metric filtering.

### DIFF
--- a/linuxproc.go
+++ b/linuxproc.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"reflect"
+
 	linuxproc "github.com/marc-barry/goprocinfo/linux"
 )
 
@@ -15,4 +17,21 @@ func readCPUInfo() (*linuxproc.CPUInfo, error) {
 
 func readNetworkDeviceStats() ([]linuxproc.NetworkStat, error) {
 	return linuxproc.ReadNetworkStat(NetworkStatPath)
+}
+
+func getNetworkDeviceStatsList() []string {
+	stat := linuxproc.NetworkStat{}
+
+	elem := reflect.ValueOf(&stat).Elem()
+	typeOfElem := elem.Type()
+
+	list := make([]string, 0)
+
+	for i := 0; i < elem.NumField(); i++ {
+		if field := typeOfElem.Field(i); field.Name != "Iface" {
+			list = append(list, field.Name)
+		}
+	}
+
+	return list
 }

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ const (
 	CollectRate              = "collect-rate"
 	StatsInterfaceFilterFlag = "stats-interface-filter"
 	StatsFlag                = "stats"
+	HelpFlag                 = "h"
 )
 
 var (
@@ -36,6 +37,7 @@ var (
 	collectRate          = flag.Int64(CollectRate, 2, "Rate (in seconds) for which the stats are collected.")
 	statsInterfaceFilter = flag.String(StatsInterfaceFilterFlag, "", "Regular expression which filters out interfaces not reported to DogStatd.")
 	statsList            = flag.String(StatsFlag, "", "The list of stats send to the DogStatsd server.")
+	help                 = flag.Bool(HelpFlag, false, "Prints help info.")
 
 	stopOnce sync.Once
 	stopWg   sync.WaitGroup
@@ -59,6 +61,13 @@ func withLogging(f func()) {
 
 func main() {
 	flag.Parse()
+
+	if *help {
+		fmt.Println("Supported stats:")
+		fmt.Println(NetworkStatPath)
+		fmt.Println("--- " + strings.Join(getNetworkDeviceStatsList(), ","))
+		os.Exit(0)
+	}
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)

--- a/statsd.go
+++ b/statsd.go
@@ -36,7 +36,9 @@ func collectNetworkDeviceStats() {
 
 				value := elem.Field(i).Uint()
 
-				if metricName := field.Tag.Get("json"); metricName != "" {
+				_, collect := StatsMap[field.Name]
+
+				if metricName := field.Tag.Get("json"); collect && metricName != "" {
 					if err := StatsdClient.Count(strings.Join([]string{metricPrefix, metricName}, ""), int64(value), []string{"iface:" + stat.Iface}, 1); err != nil {
 						Log.WithField("error", err).Error("Couldn't submit event to statsd.")
 					}


### PR DESCRIPTION
This PR adds support for metric filtering with the `-stats` command line argument.
```
/007 -http-enable -dogstatsd-address localhost:8125 -stats-interface-filter ^veth -stats RxBytes,TxBytes
```
For example, the above would only send the `RxBytes` and `TxBytes` stats to `dogstatsd-address`. There is also a `-h` command line argument which currently prints the supported stats.
```
$ ./007 -h
Supported stats:
/proc/net/dev
--- RxBytes,RxPackets,RxErrs,RxDrop,RxFifo,RxFrame,RxCompressed,RxMulticast,TxBytes,TxPackets,TxErrs,TxDrop,TxFifo,TxColls,TxCarrier,TxCompressed
```