### PR TITLE
Allow for controlling the log rate.

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ const (
 	HTTPPortFlag             = "http-port"
 	CalculateRate            = "calculate-rate"
 	CollectRate              = "collect-rate"
+	LogRate                  = "log-rate"
 	StatsInterfaceFilterFlag = "stats-interface-filter"
 	StatsFlag                = "stats"
 	JsonLogFlag              = "json-log"
@@ -36,6 +37,7 @@ var (
 	httpPort             = flag.Int(HTTPPortFlag, 8001, "HTTP server listening port.")
 	calculatedRate       = flag.Int64(CalculateRate, 2, "Rate (in seconds) for which the rate stats are calculated.")
 	collectRate          = flag.Int64(CollectRate, 2, "Rate (in seconds) for which the stats are collected.")
+	logRate              = flag.Int64(LogRate, 5, "Rate (in seconds) for which the stats are logged.")
 	statsInterfaceFilter = flag.String(StatsInterfaceFilterFlag, "", "Regular expression which filters out interfaces not reported to DogStatd.")
 	statsList            = flag.String(StatsFlag, "", "The list of stats send to the DogStatsd server.")
 	jsonLog              = flag.Bool(JsonLogFlag, false, "Enable JSON logging. The default format is text.")
@@ -180,6 +182,18 @@ func startCollectors() {
 			case <-time.Tick(time.Duration(*collectRate) * time.Second):
 				collectNetworkDeviceStats()
 				collectNetstatStats()
+			}
+		}
+	})
+}
+
+func startLoggers() {
+	go withLogging(func() {
+		for {
+			select {
+			case <-time.Tick(time.Duration(*logRate) * time.Second):
+				logNetworkDeviceStats()
+				logNetstatStats()
 			}
 		}
 	})

--- a/statsd.go
+++ b/statsd.go
@@ -50,7 +50,7 @@ func logNetworkDeviceStats() {
 	stats, err := readNetworkDeviceStats()
 
 	if err != nil {
-		Log.WithField("error", err).Error("Error reading network device stats. Can't collect network device stats.")
+		Log.WithField("error", err).Error("Error reading network device stats. Can't log network device stats.")
 	}
 
 	jsonBytes, err := json.Marshal(stats)
@@ -65,7 +65,7 @@ func collectNetstatStats() {
 	stats, err := readNetworkDeviceStats()
 
 	if err != nil {
-		Log.WithField("error", err).Error("Error reading network device stats. Can't collect network device stats.")
+		Log.WithField("error", err).Error("Error reading network device stats. Can't collect netstat stats.")
 	}
 
 	elem := reflect.ValueOf(stats).Elem()
@@ -90,7 +90,7 @@ func logNetstatStats() {
 	stats, err := readNetstatStats()
 
 	if err != nil {
-		Log.WithField("error", err).Error("Error reading network device stats. Can't collect netstat stats.")
+		Log.WithField("error", err).Error("Error reading network device stats. Can't log netstat stats.")
 	}
 
 	jsonBytes, err := json.Marshal(stats)

--- a/statsd.go
+++ b/statsd.go
@@ -19,13 +19,6 @@ func collectNetworkDeviceStats() {
 	}
 
 	for _, stat := range stats {
-		jsonBytes, err := json.Marshal(stat)
-		if err != nil {
-			Log.WithField("error", err).Errorf("Error JSON marshalling: %+v.", stat)
-		}
-
-		Log.WithField("stat", NetworkStatPath).Infof(string(jsonBytes))
-
 		if ifaceRegExp == nil || !ifaceRegExp.MatchString(stat.Iface) {
 			elem := reflect.ValueOf(&stat).Elem()
 			typeOfElem := elem.Type()
@@ -53,11 +46,11 @@ func collectNetworkDeviceStats() {
 	}
 }
 
-func collectNetstatStats() {
-	stats, err := readNetstatStats()
+func logNetworkDeviceStats() {
+	stats, err := readNetworkDeviceStats()
 
 	if err != nil {
-		Log.WithField("error", err).Error("Error reading network device stats. Can't collect netstat stats.")
+		Log.WithField("error", err).Error("Error reading network device stats. Can't collect network device stats.")
 	}
 
 	jsonBytes, err := json.Marshal(stats)
@@ -65,7 +58,15 @@ func collectNetstatStats() {
 		Log.WithField("error", err).Errorf("Error JSON marshalling: %+v.", stats)
 	}
 
-	Log.WithField("stat", NetstatStatPath).Infof(string(jsonBytes))
+	Log.WithField("stat", NetworkStatPath).Infof(string(jsonBytes))
+}
+
+func collectNetstatStats() {
+	stats, err := readNetworkDeviceStats()
+
+	if err != nil {
+		Log.WithField("error", err).Error("Error reading network device stats. Can't collect network device stats.")
+	}
 
 	elem := reflect.ValueOf(stats).Elem()
 	typeOfElem := elem.Type()
@@ -83,4 +84,19 @@ func collectNetstatStats() {
 			}
 		}
 	}
+}
+
+func logNetstatStats() {
+	stats, err := readNetstatStats()
+
+	if err != nil {
+		Log.WithField("error", err).Error("Error reading network device stats. Can't collect netstat stats.")
+	}
+
+	jsonBytes, err := json.Marshal(stats)
+	if err != nil {
+		Log.WithField("error", err).Errorf("Error JSON marshalling: %+v.", stats)
+	}
+
+	Log.WithField("stat", NetstatStatPath).Infof(string(jsonBytes))
 }


### PR DESCRIPTION
Introduce the `-log-rate` command line argument to control how often stats are logged.