### PR TITLE
Start using gauges instead of counts.

### DIFF
--- a/statsd.go
+++ b/statsd.go
@@ -44,7 +44,7 @@ func collectNetworkDeviceStats() {
 				_, collect := StatsMap[field.Name]
 
 				if metricName := field.Tag.Get("json"); collect && metricName != "" {
-					if err := StatsdClient.Count(strings.Join([]string{networkDeviceStatsMetricPrefix, metricName}, ""), int64(value), []string{"iface:" + stat.Iface}, 1); err != nil {
+					if err := StatsdClient.Gauge(strings.Join([]string{networkDeviceStatsMetricPrefix, metricName}, ""), float64(value), []string{"iface:" + stat.Iface}, 1); err != nil {
 						Log.WithField("error", err).Error("Couldn't submit event to statsd.")
 					}
 				}
@@ -88,7 +88,7 @@ func collectNetstatStats() {
 		_, collect := StatsMap[field.Name]
 
 		if metricName := field.Tag.Get("json"); collect && metricName != "" {
-			if err := StatsdClient.Count(strings.Join([]string{netstatStatsMetricPrefix, metricName}, ""), int64(value), []string{}, 1); err != nil {
+			if err := StatsdClient.Gauge(strings.Join([]string{netstatStatsMetricPrefix, metricName}, ""), float64(value), []string{}, 1); err != nil {
 				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
 			}
 		}


### PR DESCRIPTION
Based on issues we saw with DataDog graphs it was determined that gauges are the correct metric. Counts are meant to be reported as rates. The docs can be found here: http://docs.datadoghq.com/guides/metrics/
